### PR TITLE
fix: fetch higher resolution of assetImage

### DIFF
--- a/src/jsMain/kotlin/util/LanyardApi.kt
+++ b/src/jsMain/kotlin/util/LanyardApi.kt
@@ -238,6 +238,6 @@ object LanyardApi {
     }
 
     fun getAssetImage(applicationId: String, assetId: String): String {
-        return "https://cdn.discordapp.com/app-assets/${applicationId}/${assetId}.png"
+        return "https://cdn.discordapp.com/app-assets/${applicationId}/${assetId}.webp?size=512"
     }
 }


### PR DESCRIPTION
by default it returns 128x128
also changed to webp because so speed (you hate)